### PR TITLE
Fix lint & type errors; Improve control flow; Use GitHub token for API requests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM spritsail/alpine:3.14
+FROM spritsail/alpine:3.18
 
-ADD main.py requirements.txt /
+RUN apk add --no-cache \
+        python3 \
+        py3-yaml \
+        py3-pygithub
 
-RUN apk add --no-cache python3 py3-pip \
- && apk add --no-cache -t build gcc libc-dev python3-dev libffi-dev make \
- && pip3 install -r /requirements.txt \
- && apk del --no-cache build
+ADD main.py /
 
 VOLUME ["/config"]
-
 CMD ["python3","-u","/main.py","-c","/config"]

--- a/main.py
+++ b/main.py
@@ -1,61 +1,59 @@
 #!/usr/bin/env python3
+
+# pylint: disable=redefined-outer-name,invalid-name
+
 import argparse
-import json
 import logging
-from os import path
-from time import sleep
-from sys import exit  # pylint: disable=redefined-builtin
+import os
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any
 
 import github
 import requests
 import yaml
 
+ArgsType = dict[str, dict[str, str | int]]
 
-def jsonVal(url, struct):
+
+def fetch_http_json_val(url: str, struct: str, timeout: int = 30) -> Any:
     # Fetch the page data
-    try:
-        r = requests.get(url)
-        r.raise_for_status()
-        jsondata = r.text
-    except requests.HTTPError as e:
-        raise e
+    r = requests.get(url, timeout=timeout)
+    r.raise_for_status()
+    data = r.json()
 
-    # Try to load it as valid JSON
-    try:
-        dataDict = json.loads(jsondata)
-    except json.decoder.JSONDecodeError as e:
-        # Probably Not Valid JSON?
-        logging.error("Could not decode JSON: %s", jsondata)
-        raise e
+    # Shortcut if we're given an empty path
+    if struct == "":
+        return data
 
     # Iterate through each of the bits of the struct to find the key we need
     try:
-        for i in struct.split("."):
-            try:
-                i = int(i)
-                dataDict = dataDict[i]
-            except (KeyError, ValueError):
-                # Try it as a string?
-                dataDict = dataDict[i]
-        return dataDict
-
-    except KeyError:
+        for part in struct.split("."):
+            if isinstance(data, list):
+                # Let's hope the user didn't do a silly here
+                data = data[int(part)]
+            else:
+                data = data[part]
+    except (KeyError, ValueError, TypeError):
         logging.error("Invalid Structure: %s for url %s", struct, url)
         raise
 
+    return data
 
-def sanityCheck(repo_slug, args):
+
+def validate_repo(repo_slug: str, args: ArgsType, timeout: int = 30) -> bool:
     # Get the repo & branch from the slug
-    repo, branch = getBranch(repo_slug)
+    repo, branch = parse_repo_branch(repo_slug)
 
     # Check the args
     if "args" not in args:
         logging.critical("Malformed config file - missing args for repo %s", repo)
-        exit(78)
+        return False
 
     if not isinstance(args["args"], dict):
         logging.critical("Malformed config file - missing args for repo %s", repo)
-        exit(78)
+        return False
 
     # Check if the github repo exists & is writable using the given token
     # There is obviously a large toctou issue here, but github api limits mean we just have to deal.
@@ -63,224 +61,223 @@ def sanityCheck(repo_slug, args):
         gitrepo = git.get_repo(repo)
     except github.UnknownObjectException:
         logging.critical("Repo does not exist: %s", repo)
+        return False
 
     if not gitrepo.permissions.pull:
         logging.critical("Do not have pull permissions for repo %s", repo)
-        exit(78)
+        return False
 
     if not gitrepo.permissions.push:
         logging.critical("Do not have push permissions for repo %s", repo)
-        exit(78)
+        return False
 
     # Check for branch existing.
     try:
         gitrepo.get_branch(branch)
     except github.GithubException:
         logging.critical("Branch %s not found in repo %s", branch, repo)
-        exit(78)
+        return False
 
     # Check for existance of Dockerfile in each repo
     try:
         dockerfile = gitrepo.get_contents("Dockerfile", branch).decoded_content.decode()
     except github.UnknownObjectException:
         logging.critical("Dockerfile not found on branch %s of repo %s", branch, repo)
-        exit(78)
+        return False
 
     # Check parsed Dockerfile to make sure it has at least one ARG with a value
-    dockerfile_args = getArgs(dockerfile)
+    dockerfile_args = parse_dockerfile_args(dockerfile)
     if not dockerfile_args:
         logging.critical("No arguments found in Dockerfile in repo %s", repo)
-        exit(78)
+        return False
 
     # Iterate through each arg to check for requried opts & basic URL check
     for arg, options in args["args"].items():
         # Check that arg config structure is correct
         if "url" not in options:
             logging.critical("missing url for arg %s in repo %s", arg, repo)
-            exit(78)
+            return False
 
         if "structure" not in options:
             logging.critical("missing structure for arg %s in repo %s", arg, repo)
-            exit(78)
+            return False
 
         # Check if arg exists in Dockerfile
         if arg not in dockerfile_args:
             logging.critical("Argument %s missing in Dockerfile for repo %s", arg, repo)
-            exit(78)
+            return False
 
         # Check if URL goes somewhere valid.
         try:
-            r = requests.get(options["url"])
-            r.raise_for_status()
+            fetch_http_json_val(options["url"], "", timeout=timeout)
         except requests.HTTPError as e:
             logging.warning(
-                "Got Response code %s for URL %s while running startup checks",
-                str(e.response.status_code),
-                str(options["url"]),
+                "Got Response code %d for URL %s while running startup checks",
+                e.response.status_code,
+                options["url"],
             )
 
+    return True
 
-def getBranch(repo_string):
-    split = repo_string.split("@")
 
-    repo = split[0]
+def parse_repo_branch(repo_string: str) -> tuple[str, str]:
+    split = repo_string.split("@", 2)
+
     if len(split) > 1:
-        branch = split[1]
-    else:
-        branch = "master"
-
-    return repo, branch
+        return split[0], split[1]
+    return split[0], "master"
 
 
-def getArgs(raw_dockerfile):
+@dataclass
+class DockerfileArgument:
+    value: str
+    line: int
+
+
+def parse_dockerfile_args(raw_dockerfile: str) -> dict[str, DockerfileArgument]:
     arguments = {}
 
     for num, line in enumerate(raw_dockerfile.split("\n")):
         if line.startswith("ARG "):
             arg = line[4:].strip().split("=", 1)
             if len(arg) > 1:
-                arguments[arg[0]] = {"value": arg[1], "line": num}
+                arguments[arg[0]] = DockerfileArgument(value=arg[1], line=num)
 
     return arguments
 
 
-def updateArg(dockerfile, arg, line, version):
+def update_dockerfile_arg(dockerfile: str, arg: str, line: int, version: str) -> str:
     # Theres probably a cleaner way of doing this, but eh.
     lines = dockerfile.split("\n")
     lines[line] = f"ARG {arg}={version}"
     return "\n".join(lines)
 
 
-# TODO: Option for logging to file?
-log_format = "%(asctime)s - %(levelname)s - %(message)s"
-logging.basicConfig(format=log_format, level=logging.INFO)
+if __name__ == "__main__":
+    # TODO: Option for logging to file?
+    logging.basicConfig(
+        format="%(asctime)s - %(levelname)s - %(message)s", level=logging.INFO
+    )
 
-argparser = argparse.ArgumentParser(
-    prog="Docker Arg Updater",
-    description="Docker Arg Updater commits updates to programs using Docker Args",
-)
-argparser.add_argument("-c", "--config", help="Specify config file")
-cmdargs = argparser.parse_args()
+    argparser = argparse.ArgumentParser(
+        prog="Docker Arg Updater",
+        description="Docker Arg Updater commits updates to programs using Docker Args",
+    )
+    argparser.add_argument("-c", "--config", help="Specify config file")
+    cmdargs = argparser.parse_args()
 
-if not (cmdargs.config):
-    filepath = "."
-else:
-    filepath = cmdargs.config
+    filepath = cmdargs.config or "."
+    # If the filepath is a directory, add the filename on the end.
+    if os.path.isdir(filepath):
+        filepath = f"{filepath}/config.yaml"
 
-# If the filepath is a directory, add the filename on the end.
-if path.isdir(filepath):
-    filepath = f"{filepath}/config.yaml"
+    if not os.path.isfile(filepath):
+        logging.critical("Config file does not exist")
+        sys.exit(78)
 
-if not path.isfile(filepath):
-    logging.critical("Config file does not exist")
-    exit(78)
-
-# Open & load the config file
-with open(filepath, "r") as stream:
-    try:
+    # Open & load the config file
+    with open(filepath, encoding="utf-8") as stream:
         cfg = yaml.safe_load(stream)
-    except yaml.YAMLError:
-        logging.critical("Error loading config: Not valid YAML")
-        exit(78)
 
-# Check if the config stanza exists
-if "config" not in cfg:
-    logging.critical("Error loading config: config block missing")
-    exit(78)
+    # Check if the config stanza exists
+    if "config" not in cfg:
+        logging.critical("Error loading config: config block missing")
+        sys.exit(78)
 
-if not cfg["config"]:
-    logging.critical("Error loading config: config block empty")
-    exit(78)
+    if not cfg["config"]:
+        logging.critical("Error loading config: config block empty")
+        sys.exit(78)
 
-# Check if the access token exists
-if "access_token" not in cfg["config"]:
-    logging.critical("Error loading config: Access token missing")
-    exit(78)
+    # Check if the access token exists
+    if "access_token" not in cfg["config"]:
+        logging.critical("Error loading config: Access token missing")
+        sys.exit(78)
 
-token = cfg["config"]["access_token"]
+    token = cfg["config"]["access_token"]
 
-# Log into the GH API, check if token is valid
-try:
-    git = github.Github(token)
-except github.BadCredentialsException:
-    # TODO: Annoyingly, GitHub library eats this exception and bombs out of its own accord. How Rude.
-    logging.critical("Error loading config: Invalid access token")
-    exit(78)
+    # Log into the GH API, check if token is valid
+    try:
+        git = github.Github(token)
+    except github.BadCredentialsException:
+        # TODO: Annoyingly, GitHub library eats this exception and bombs out of its
+        # own accord. How Rude.
+        logging.critical("Error loading config: Invalid access token")
+        sys.exit(78)
 
-# Check for a sleep timer config - default to 30 mins if not
-if "sleep_time" in cfg["config"]:
-    sleeptime = cfg["config"]["sleep_time"]
-else:
-    sleeptime = 1800
+    # Check for a sleep timer config - default to 30 mins if not
+    sleeptime = cfg["config"].get("sleep_time", 1800)
 
-# This way, we just get a list of the repos.
-del cfg["config"]
+    # This way, we just get a list of the repos.
+    del cfg["config"]
 
-# Run a sanity check on each of the repos
-for repo, args in cfg.items():
-    sanityCheck(repo, args)
+    # Run a sanity check on each of the repos
+    logging.info("Performing startup validation checks...")
+    for repo, args in cfg.items():
+        try:
+            if not validate_repo(repo, args):
+                sys.exit(78)
+        except Exception:  # pylint: disable=broad-except
+            logging.exception("Failed to validate repo %s", repo)
+            sys.exit(78)
 
-logging.info("Config valid, daemon started")
+    logging.info("Config valid, daemon started")
 
-while True:
-    for repo_slug, args in cfg.items():
-
-        # Get the repo & branch from the slug
-        repo, branch = getBranch(repo_slug)
-
-        gitrepo = git.get_repo(repo)
-        gitfile = gitrepo.get_contents("Dockerfile", branch)
-
-        # The get_contents func returns a byte array, for some reason.. Double decoding ftw
-        dockerfile = gitfile.decoded_content.decode()
-
-        # Get an array of all the args
-        dockerfile_args = getArgs(dockerfile)
-
-        commitmsg = []
-        for arg, data in args["args"].items():
-
-            arg_data = cfg[repo_slug]["args"][arg]
-            oldver = dockerfile_args[arg]["value"]
+    while True:
+        for repo_slug, args in cfg.items():
             try:
-                newver = jsonVal(arg_data["url"], arg_data["structure"])
-            except Exception as err:
-                logging.warning(
-                    "%s : %s getting new version for argument %s, skipping....",
+                # Get the repo & branch from the slug
+                repo, branch = parse_repo_branch(repo_slug)
+
+                gitrepo = git.get_repo(repo)
+                gitfile = gitrepo.get_contents("Dockerfile", branch)
+                dockerfile = gitfile.decoded_content.decode()
+
+                # Get an array of all the args
+                dockerfile_args = parse_dockerfile_args(dockerfile)
+
+                commitmsg = []
+                for arg, data in args["args"].items():
+                    arg_data = cfg[repo_slug]["args"][arg]
+                    oldver = dockerfile_args[arg].value
+                    newver = fetch_http_json_val(arg_data["url"], arg_data["structure"])
+
+                    # Do we need to strip data off the front of the string?
+                    if "strip_front" in data:
+                        newver = newver.split(data["strip_front"], 1)[1]
+
+                    if oldver != newver:
+                        # Pass the Dockerfile into the writer
+                        line: int = dockerfile_args[arg].line
+                        dockerfile = update_dockerfile_arg(
+                            dockerfile, arg, line, newver
+                        )
+
+                        if "human_name" in data:
+                            arg_name = data["human_name"]
+                        else:
+                            arg_name = arg
+                        argmessage = f"Updated {arg_name} to {newver}"
+                        commitmsg.append(argmessage)
+
+                if commitmsg:
+                    if len(commitmsg) > 1:
+                        commitstr = " & ".join(commitmsg)
+                    else:
+                        commitstr = commitmsg[0]
+
+                    gitrepo.update_file(
+                        gitfile.path, commitstr, dockerfile, gitfile.sha, branch
+                    )
+                    logging.info("%s: %s", repo_slug, commitstr)
+
+            except Exception as err:  # pylint: disable=broad-except
+                logging.error(
+                    "%s: %s getting new version for argument %s, skipping....",
                     repo_slug,
                     err,
                     arg,
                 )
                 continue
 
-            # Do we need to strip data off the front of the string?
-            if "strip_front" in data:
-                newver = newver.split(data["strip_front"], 1)[1]
-
-            if oldver != newver:
-                # Pass the Dockerfile into the writer
-                dockerfile = updateArg(
-                    dockerfile, arg, dockerfile_args[arg]["line"], newver
-                )
-
-                if "human_name" in data:
-                    arg_name = data["human_name"]
-                else:
-                    arg_name = arg
-                argmessage = f"Updated {arg_name} to {newver}"
-                commitmsg.append(argmessage)
-
-        if commitmsg:
-            if len(commitmsg) > 1:
-                s = " & "
-                commitstr = s.join(commitmsg)
-            else:
-                commitstr = commitmsg[0]
-
-            gitrepo.update_file(
-                gitfile.path, commitstr, dockerfile, gitfile.sha, branch
-            )
-            logging.info("%s : %s", repo_slug, commitstr)
-
-    # D-d-d-d d-d-d-do it again
-    sleep(sleeptime)
+        # D-d-d-d d-d-d-do it again
+        time.sleep(sleeptime)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-PyYAML>=5.4.1
-PyGithub>=1.54.1
+PyYAML>=6.0
+PyGithub>=1.59.0


### PR DESCRIPTION
Be a little smarter with control flow. Use a __main__ block. Handle errors in the main loop better by catching them and logging instead of just exiting hard.

Using the GitHub API token avoids exhausting the extremely low unauthenticated github API limit.

Signed-off-by: Joe Groocock <me@frebib.net>